### PR TITLE
Add instructions to disable logger to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,9 @@ Logging is done via the [winston](https://github.com/winstonjs/winston), the win
 ```js
 orm.logger.level = "debug";
 ```
+
+To disable logging entirely:
+
+```js
+orm.logger.level = null
+```


### PR DESCRIPTION
I haven't used Winston in a long time and had to figure this out.

Thought it might be useful to include in the readme.
