### PR TITLE
chore(package): Add commitizen dependency and script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/jspizziri/sequelize-connect.git"
   },
+  "scripts": {
+    "commit": "git-cz"
+  },
   "keywords": [
     "sequelize",
     "singleton",
@@ -21,6 +24,7 @@
   ],
   "dependencies": {
     "bluebird": "^2.10.2",
+    "commitizen": "^2.7.6",
     "lodash": "^3.10.1",
     "winston": "^1.1.1"
   },


### PR DESCRIPTION
Like you requested in #4, I have added `commitizen` as a local dependency. To make it easy to invoke, I also added a small npm script called `commit`.
