### PR TITLE
ISSUE-19 | model discover includes non js files - Update filter for filename search

### DIFF
--- a/src/Discoverable.js
+++ b/src/Discoverable.js
@@ -63,7 +63,7 @@ class Discoverable {
         if(typeof this.matcher === 'function' && this.matcher(file) === true) {
           this._log("debug", "Discovered path: " + path);
           return path;
-        } else if((file.indexOf(".") !== 0) && (file.indexOf(".model.js") > 0)) {
+        } else if(/^[^.].*?\.model\.js$/.test(file)) {
           this._log("debug", "Discovered path: " + path);
           return path;
         }


### PR DESCRIPTION
In response to Issue #19 
This change will only catch files not starting with a dot `.` and ending with `.model.js`
This will enable files such as `user.model.js.map` to not break the application, even though it consists of `.model.js`!

`user.model.js` ✔️
`user.model.js.map` ❌